### PR TITLE
feat: add retrieval of estimated date of delivery / date of delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The `track_package` service creates a sensor for each tracked package with the f
 | location        |	Latest known location of the parcel                                |
 | origin          |	Country of departure                                               |
 | destination     |	Destination country or address                                     |
+| delivered_by    |	Estimated date of delivery                                         |
 | carrier         |	Delivery company name                                              |
 | days_in_transit |	Number of days the parcel has been in transit                      |
 | last_updated    |	Timestamp of the latest check by the integration                   |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The `track_package` service creates a sensor for each tracked package with the f
 | location        |	Latest known location of the parcel                                |
 | origin          |	Country of departure                                               |
 | destination     |	Destination country or address                                     |
-| delivered_by    |	Estimated date of delivery                                         |
+| delivered_by    |	Estimated date of delivery / date of delivery                      |
 | carrier         |	Delivery company name                                              |
 | days_in_transit |	Number of days the parcel has been in transit                      |
 | last_updated    |	Timestamp of the latest check by the integration                   |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ During setup, you'll need to provide:
 
 1. Your ParcelsApp API key (obtainable from [parcelsapp.com/dashboard](https://parcelsapp.com/dashboard))
 2. Your destination country (the name of your country in your native language)
+3. If you are getting errors, make sure you have answered the email sent from parcelsapp to confirm your account. It may have gone to spam.
 
 ## Usage
 

--- a/custom_components/parcelsapp/coordinator.py
+++ b/custom_components/parcelsapp/coordinator.py
@@ -114,6 +114,7 @@ class ParcelsAppCoordinator(DataUpdateCoordinator):
                         "location": shipment.get("lastState", {}).get("location", "undefined"),
                         "origin": shipment.get("origin"),
                         "destination": shipment.get("destination"),
+                        "delivered_by": shipment.get("delivered_by"),
                         "carrier": shipment.get("detectedCarrier", {}).get("name"),
                         "days_in_transit": next(
                             (
@@ -179,6 +180,7 @@ class ParcelsAppCoordinator(DataUpdateCoordinator):
                     "location": shipment_data.get("lastState", {}).get("location", "undefined"),
                     "origin": shipment_data.get("origin"),
                     "destination": shipment_data.get("destination"),
+                    "delivered_by": shipment_data.get("delivered_by"),
                     "carrier": shipment_data.get("detectedCarrier", {}).get("name"),
                     "days_in_transit": next(
                         (
@@ -313,6 +315,7 @@ class ParcelsAppCoordinator(DataUpdateCoordinator):
                         "location": shipment.get("lastState", {}).get("location", "undefined"),
                         "origin": shipment.get("origin"),
                         "destination": shipment.get("destination"),
+                        "delivered_by": shipment.get("delivered_by"),
                         "carrier": shipment.get("detectedCarrier", {}).get("name"),
                         "days_in_transit": next(
                             (


### PR DESCRIPTION
API requests give an additional information if available: delivered-by, the estimated date of delivery before delivery, the date of delivery when delivered. This PR aims at collecting it in the attributes of the parcel sensor.

Example of attributes received:
status: transit
uuid: xxx
uuid_timestamp: 2025-05-29T12:40:24.343190
message: La livraison de votre Colissimo est prévue
last_updated: 2025-05-29 16:36:01.394959
name: xxx
location: undefined
origin: France
destination: France
carrier: La Poste
days_in_transit: 2
**delivered_by: 2025-05-30T00:00:00Z**
tracking_id: xxx
icon: mdi:package-variant-closed
friendly_name: xxx
