### PR TITLE
Fix tracking numeric IDs

### DIFF
--- a/custom_components/parcelsapp/coordinator.py
+++ b/custom_components/parcelsapp/coordinator.py
@@ -259,7 +259,7 @@ class ParcelsAppCoordinator(DataUpdateCoordinator):
             {
                 "shipments": [
                     {
-                        "trackingId": tracking_id,
+                        "trackingId": str(tracking_id).strip(),
                         "destinationCountry": self.destination_country,
                     }
                 ],

--- a/custom_components/parcelsapp/coordinator.py
+++ b/custom_components/parcelsapp/coordinator.py
@@ -69,7 +69,7 @@ class ParcelsAppCoordinator(DataUpdateCoordinator):
             {
                 "shipments": [
                     {
-                        "trackingId": tracking_id,
+                        "trackingId": str(tracking_id).strip(),
                         "destinationCountry": self.destination_country,
                     }
                 ],


### PR DESCRIPTION
When using a template to set the tracking ID, a value containing only numeric digits (e.g. USPS, FedEx) is treated as an int, leading to an HTTP 400 error from the ParcelsApp API. Cast to a str to fix this case.

Closes #12.